### PR TITLE
Update fpu.py to handle ARM CPUs

### DIFF
--- a/interval/fpu.py
+++ b/interval/fpu.py
@@ -34,6 +34,8 @@ def _init_libm():  # pragma: nocover
         _fe_upward, _fe_downward = 2, 3
     elif processor == 'sparc':
         _fe_upward, _fe_downward = 0x80000000, 0xC0000000
+    elif processor == 'arm':
+        _fe_upward, _fe_downward = 0x400000, 0x800000
     else:
         _fe_upward, _fe_downward = 0x0800, 0x0400
 


### PR DESCRIPTION
Fix for arm (tested on macos) fpu rounding.

Without this fix, rounding downward/upward don't work and some computations that should lead to very small intervals results in degenerated intervals.